### PR TITLE
Fix dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.18 AS build
+FROM golang:1.22 AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
I couldn't compile the Docker image, so I used a more recent version of the golang and it worked! You can now compile the image again. Please test the modification before pulling because I couldn't get it to work, I have a problem with Redis, but it should work fine.